### PR TITLE
Add debugging information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,14 @@ passed directly to the `cargo build` command.
 Note that specifying the CMake generator is required on the first build only. Subsequent builds will
 use the cached generator, unless `cargo hdk --clean` is run, which clears all build artifacts.
 
+# Debugging
+
+If you are having trouble with the build process, this crate implements [clap-verbosity-flag](https://crates.io/crates/clap-verbosity-flag), which means logging can be output with the following flags
+
+```
+cargo hdk -q # silences output
+cargo hdk -v # show warnings
+cargo hdk -vv # show info
+cargo hdk -vvv # show debug
+cargo hdk -vvvv show trace
+```

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ use the cached generator, unless `cargo hdk --clean` is run, which clears all bu
 If you are having trouble with the build process, this crate implements [clap-verbosity-flag](https://crates.io/crates/clap-verbosity-flag), which means logging can be output with the following flags
 
 ```
-cargo hdk -q # silences output
-cargo hdk -v # show warnings
-cargo hdk -vv # show info
-cargo hdk -vvv # show debug
-cargo hdk -vvvv show trace
+cargo hdk -q    # silences output
+cargo hdk -v    # show warnings
+cargo hdk -vv   # show info
+cargo hdk -vvv  # show debug
+cargo hdk -vvvv # show trace
 ```


### PR DESCRIPTION
This is a minor update to debugging information in the README. I'm just suggesting this update because it would have saved me a few minutes time when I was trying to debug what was going on with `cargo hdk`